### PR TITLE
docs: fix README performance chart URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ construction are 30 to 70 percent faster.
 
 The benchmark script is in `load_test/load_test.py`.
 
-![Performance Chart](assets/performance_chart.png)
+![Performance Chart](https://raw.githubusercontent.com/roman-right/vldt/main/assets/performance_chart.png)
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- update the README performance chart image to use the same raw GitHub URL style as the logo
- keep the chart visible when the README is rendered outside the repository, such as package metadata pages

Related to #49. I did not find smart quotes or apostrophes in the current README, so this PR only handles the broken chart reference.

## Checks
- git diff --check
- rg -n "Performance Chart" README.md
- python -m pytest tests/test_docs.py (blocked locally: the C++ extension module vldt._vldt is not built in this checkout)
